### PR TITLE
Optionally disable a mapping's surjective check

### DIFF
--- a/src/AdditionalSettings.cpp
+++ b/src/AdditionalSettings.cpp
@@ -99,6 +99,7 @@ AdditionalSettingsDialog::AdditionalSettingsDialog(const mv::Dataset<Points>& cu
     mv::util::Serializable("AdditionalSettingsDialog"),
     _okButton(this, "Ok"),
     _selectionMappingSourcePicker(this, "Selection mapping source"),
+    _checkMappingSurjective(this, "Check mapping surjectivity", true),
     _currentDataGUID(this, "currentDataGUID")
 {
     setWindowTitle("Additional DE Viewer settings");
@@ -106,6 +107,8 @@ AdditionalSettingsDialog::AdditionalSettingsDialog(const mv::Dataset<Points>& cu
     setModal(false);
 
     setCurrentData(currentData);
+
+    _checkMappingSurjective.setToolTip("Only un-check this if you really know what you are doing.");
 
     connect(&_okButton, &mv::gui::TriggerAction::triggered, this, &QDialog::accept);
 
@@ -115,6 +118,7 @@ AdditionalSettingsDialog::AdditionalSettingsDialog(const mv::Dataset<Points>& cu
 
     layout->addWidget(_selectionMappingSourcePicker.createLabelWidget(this), ++row, 0, 1, 1);
     layout->addWidget(_selectionMappingSourcePicker.createWidget(this), row, 1, 1, -1);
+    layout->addWidget(_checkMappingSurjective.createWidget(this), ++row, 1, 1, -1);
 
     layout->addWidget(_okButton.createWidget(this), ++row, 0, 1, -1, Qt::AlignRight);
 

--- a/src/AdditionalSettings.h
+++ b/src/AdditionalSettings.h
@@ -63,6 +63,19 @@ bool checkSurjectiveMapping(const mv::LinkedData* linkedData, const std::uint32_
 // checks whether the mapping covers all elements in the target
 bool checkSelectionMapping(const mv::Dataset<Points>& other, const mv::Dataset<Points>& current);
 
+inline bool isMappingValid(const mv::LinkedData* selectionMapping, unsigned int numPointsTarget, const mv::Dataset<Points>& testData, bool checkSurjective = true) {
+    if (!selectionMapping)
+        return false;
+    
+    if (numPointsTarget != testData->getNumPoints())
+        return false;
+
+    if (checkSurjective)
+        return checkSurjectiveMapping(selectionMapping, numPointsTarget);
+
+    return true;
+}
+
 // 
 // AdditionalSettingsDialog
 //

--- a/src/AdditionalSettings.h
+++ b/src/AdditionalSettings.h
@@ -87,6 +87,8 @@ public: // Getter
 
     mv::gui::DatasetPickerAction& getSelectionMappingSourcePicker() { return _selectionMappingSourcePicker; }
 
+    bool checkMappingSurjective() const { return _checkMappingSurjective.isChecked(); }
+
     std::vector<uint32_t>& getSelection(const QString& selectionName) {
         if (selectionName == "A")
             return _selectionA;
@@ -105,6 +107,7 @@ public: // Setter
 private:
     mv::gui::TriggerAction          _okButton;
     mv::gui::DatasetPickerAction    _selectionMappingSourcePicker;
+    mv::gui::ToggleAction           _checkMappingSurjective;
 
     mv::Dataset<Points>             _currentData = {};
     mv::gui::StringAction           _currentDataGUID;      // internal for serialization

--- a/src/DifferentialExpressionPlugin.cpp
+++ b/src/DifferentialExpressionPlugin.cpp
@@ -398,10 +398,7 @@ void DifferentialExpressionPlugin::init()
 
             // Check if the selection mapping makes sense
             const auto [selectionMapping, numPointsTarget] = getSelectionMappingOtherToCurrent(otherData, _points);
-            const bool useOtherSelection =
-                selectionMapping != nullptr &&
-                numPointsTarget == _points->getNumPoints() &&
-                checkSurjectiveMapping(selectionMapping, numPointsTarget);
+            const bool useOtherSelection = isMappingValid(selectionMapping, numPointsTarget, _points, _additionalSettingsDialog.checkMappingSurjective());
 
             otherData->getSelection<Points>()->indices = useOtherSelection ? _additionalSettingsDialog.getSelection(selectionName) : std::vector<uint32_t>{};
             


### PR DESCRIPTION
Highlighting a selection currently always checks if the selection mapping is subjective. Strictly, this does not have to be the case, but ideally it should. This PR add an option to skip this check.